### PR TITLE
Include Has*Query traits in DbTrait to fix bounds explosion

### DIFF
--- a/crates/picante-macros/src/db.rs
+++ b/crates/picante-macros/src/db.rs
@@ -300,10 +300,10 @@ pub(crate) fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
         let query_ty = tracked.qualify(&query_ty_ident);
         let has_trait = tracked.qualify(&has_trait_ident);
 
-        // NOTE: We intentionally do NOT add Has*Query traits to the combined db trait.
-        // Query traits can have user-specified bounds that might reference the combined trait,
-        // which would create a cycle. Instead, query dependencies are expressed through
-        // explicit bounds on tracked functions.
+        // Include Has*Query traits in the combined db trait.
+        // This is safe because Has*Query supertraits no longer include user-specified bounds
+        // (they only require IngredientLookup + Send + Sync + 'static).
+        has_trait_bounds.push(quote! { #has_trait });
 
         let getter = format_ident!("{func_snake}_query");
         let make_ident = format_ident!("make_{func_snake}_query");

--- a/crates/picante-macros/src/tracked.rs
+++ b/crates/picante-macros/src/tracked.rs
@@ -78,13 +78,16 @@ pub(crate) fn expand(item: TokenStream) -> TokenStream {
     let return_ty = parsed.return_type;
     let body = parsed.body;
 
-    let supertraits = if db_bounds.is_empty() {
+    // Has*Query traits use minimal supertraits (no user bounds).
+    // This allows DbTrait to include Has*Query without cycle risk.
+    // User bounds only apply to make_*_query() constructor.
+    let supertraits = quote! { picante::IngredientLookup + Send + Sync + 'static };
+
+    let make_bounds = if db_bounds.is_empty() {
         quote! { picante::IngredientLookup + Send + Sync + 'static }
     } else {
         quote! { #db_bounds + picante::IngredientLookup + Send + Sync + 'static }
     };
-
-    let make_bounds = supertraits.clone();
 
     let impl_where_clause = if db_bounds.is_empty() {
         TokenStream2::new()


### PR DESCRIPTION
## Summary

- Removes user bounds from `Has*Query` trait supertraits (they now only require `IngredientLookup + Send + Sync + 'static`)
- Includes all `Has*Query` traits in the generated `DbTrait`
- User bounds still apply to `make_*_query()` constructors

## Problem

When tracked functions call other tracked functions, each caller needed explicit `Has*Query` bounds:

```rust
#[picante::tracked]
async fn render_page<DB: Db 
    + HasBuildTreeQuery 
    + HasLoadAllTemplatesQuery 
    + HasLoadAllDataRawQuery
>(db: &DB, route: Route) -> PicanteResult<RenderedHtml> {
    let tree = build_tree(db).await?;
    // ...
}
```

With 30+ tracked functions, this explodes into unmanageable boilerplate.

## Solution

Users can now write:

```rust
#[picante::tracked]
async fn render_page<DB: DbTrait>(db: &DB, route: Route) -> PicanteResult<RenderedHtml> {
    let tree = build_tree(db).await?;  // Just works - DbTrait includes HasBuildTreeQuery
    let templates = load_all_templates(db).await?;
    let data = load_all_data_raw(db).await?;
    // ...
}
```

## Why this is safe

Previously, `Has*Query` supertraits included user bounds, which could create cycles if someone wrote `DB: DbTrait` in a tracked function. Now `Has*Query` has minimal supertraits, so `DbTrait: Has*Query` doesn't create any cycle.

## Test plan

- [x] All existing tests pass
- [x] Clippy clean
- [x] Pre-push hooks pass

Closes #18