### PR TITLE
Update documentation to reflect current capabilities

### DIFF
--- a/docs/content/guide/_index.md
+++ b/docs/content/guide/_index.md
@@ -3,5 +3,4 @@ title = "Guide"
 description = "How picante works"
 +++
 
-This guide explains the current picante runtime: the core ingredients, how invalidation works, and how cache persistence is structured.
-
+This guide explains the current picante runtime: the core ingredients, how invalidation works, how cache persistence is structured, and how to use snapshots for consistent reads.

--- a/docs/content/guide/comparisons.md
+++ b/docs/content/guide/comparisons.md
@@ -18,6 +18,33 @@ picante is different in a few key ways:
 - **tokio-first / async-first**: derived queries are `async` and single-flight.
 - **facet-based persistence**: picante avoids serde and uses [facet](https://facets.rs) + [facet-postcard](https://docs.rs/facet-postcard).
 - **no durability tiers**: picante tracks dependencies precisely, so it doesn't need them.
+- **MVCC snapshots**: picante uses structural sharing for point-in-time database snapshots.
+
+### MVCC vs cooperative locking
+
+salsa and picante take fundamentally different approaches to handling concurrent access:
+
+**salsa: cooperative locking / cancellation**
+
+When inputs change while a query is running, salsa can *cancel* the in-progress computation and restart it with the new inputs. This ensures queries always see consistent, up-to-date values — but requires queries to be cancellation-aware.
+
+**picante: MVCC (Multi-Version Concurrency Control)**
+
+picante uses `im::HashMap` for structural sharing. You can create cheap O(1) *snapshots* that capture a point-in-time view of the database:
+
+```rust
+let snapshot = DatabaseSnapshot::from_database(&db).await;
+
+// Snapshot sees inputs as they were at creation time
+// Changes to `db` don't affect the snapshot
+let result = my_query(&snapshot, key).await?;
+```
+
+This means:
+- Readers never block writers
+- Multiple snapshots can exist concurrently at different versions
+- No cancellation needed — queries run to completion against their snapshot
+- Useful for diffing, parallel processing, and consistent multi-query reads
 
 ### Why no durability?
 
@@ -33,10 +60,9 @@ Durability is an optimization to *skip* dependency checking — the assumption b
 
 ## Plain memoization
 
-Simple memoization caches values, but without dependency edges you can’t answer:
+Simple memoization caches values, but without dependency edges you can't answer:
 
-- “what depends on this input?”
-- “what needs to be recomputed?”
+- "what depends on this input?"
+- "what needs to be recomputed?"
 
 picante records explicit dependencies between queries while computing.
-

--- a/docs/content/guide/future.md
+++ b/docs/content/guide/future.md
@@ -1,13 +1,19 @@
 +++
 title = "Future Work"
-weight = 4
+weight = 5
 +++
 
 Some next steps that are intentionally not in v1:
 
-- **Dependency-based revalidation**: reuse values across revisions when deps are unchanged.
-- **Output fingerprinting / changed_at tracking**: avoid rebuilding unchanged downstream nodes.
 - **Cross-task cycle detection**: detect deadlocks across tasks (wait-graph).
-- **More ingredient kinds**: accumulators, durability tiers.
+- **More ingredient kinds**: accumulators for collecting values across queries.
 - **Smarter cache limits**: eviction strategies and incremental persistence.
+- **Parallel query execution**: run independent queries concurrently within a single request.
 
+## Already implemented
+
+These features were originally planned for later but are now available:
+
+- **Database snapshots**: point-in-time views for consistent reads (see [Snapshots](../snapshots/)).
+- **Dependency-based revalidation**: cached values are reused when their dependencies haven't changed.
+- **Output fingerprinting**: queries track `changed_at` vs `verified_at` to enable early cutoff — if a query recomputes but produces the same result, downstream queries skip recomputation.

--- a/docs/content/guide/motivation.md
+++ b/docs/content/guide/motivation.md
@@ -3,14 +3,150 @@ title = "Motivation"
 weight = 1
 +++
 
-picante exists because the "[salsa](https://salsa-rs.netlify.app/) model" is extremely useful for large pipelines, but [dodeca](https://dodeca.dev)'s query graph needs **async** queries.
+picante exists because the "[salsa](https://salsa-rs.netlify.app/) model" is extremely useful for large pipelines, but real-world systems need **async** queries.
 
-In [dodeca](https://dodeca.dev), many queries naturally want to:
+## The Problem
 
-- read files concurrently,
-- call plugins (often in separate processes),
-- spawn work on a thread pool,
-- stream data.
+Consider a static site generator like [dodeca](https://dodeca.dev). Building a site involves:
 
-Keeping those queries deterministic while still getting incremental recomputation is the point of picante.
+```
+SourceFile → parse_file → build_tree → render_page → all_rendered_html → build_site
+                               ↑
+TemplateFile → load_template ──┘
+```
 
+Every arrow is a query. Queries depend on other queries. When a file changes, you want to rebuild *only* what actually depends on that file — not the entire site.
+
+The salsa model solves this beautifully:
+- Queries are memoized functions
+- Dependencies are tracked automatically during execution
+- When inputs change, only affected queries recompute
+
+But dodeca's queries naturally want to:
+- Read files concurrently
+- Call plugins in separate processes (via RPC)
+- Spawn work on a thread pool
+- Stream large data through shared memory
+
+Salsa's queries are synchronous. Wrapping async in `block_on` everywhere defeats the purpose of async. picante provides the same incremental model, but with first-class async support.
+
+## The Stack
+
+picante is the foundation of a layered architecture:
+
+```
+┌────────────────────────────────────────┐
+│  your application (e.g., dodeca)       │  ← domain-specific queries
+├────────────────────────────────────────┤
+│  tacos                                 │  ← file watching, CAS, hashing
+├────────────────────────────────────────┤
+│  picante                               │  ← pure incremental queries
+└────────────────────────────────────────┘
+```
+
+**picante** handles the core incremental computation: dependency tracking, memoization, cache invalidation, and persistence.
+
+**[tacos](https://github.com/bearcove/tacos)** builds on picante to provide build-system infrastructure: file watching, content-addressed storage for large blobs, and content hashing for cache keys.
+
+Your application defines domain-specific queries on top of this stack.
+
+## Real-World Example: dodeca
+
+Here's how these layers work together in [dodeca](https://dodeca.dev):
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    HOST (dodeca binary)                     │
+│                                                             │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │                      PICANTE                          │  │
+│  │  • Tracks dependencies between queries                │  │
+│  │  • Caches query results (memoization)                 │  │
+│  │  • Knows what's stale when inputs change              │  │
+│  │  • Persists cache to disk via facet-postcard          │  │
+│  └───────────────────────────────────────────────────────┘  │
+│                            │                                │
+│  ┌────────────────────────┼────────────────────────────┐   │
+│  │          CAS           │                            │   │
+│  │  • Content-addressed   │  Host reads/writes         │   │
+│  │  • Large blobs on disk │  Plugins never touch       │   │
+│  │  • Survives restarts   │                            │   │
+│  └────────────────────────┼────────────────────────────┘   │
+│                           │                                 │
+│  ┌────────────────────────▼────────────────────────────┐   │
+│  │              PROVIDER SERVICES                       │   │
+│  │  • resolve_template(name) → content                 │   │
+│  │  • resolve_import(path) → content                   │   │
+│  │  • get_data(key) → value                            │   │
+│  │  (all picante-tracked!)                             │   │
+│  └────────────────────────┬────────────────────────────┘   │
+└───────────────────────────┼─────────────────────────────────┘
+                            │ rapace RPC + SHM
+┌───────────────────────────▼─────────────────────────────────┐
+│                  PLUGINS (separate processes)               │
+│  • Pure async functions                                     │
+│  • No caching knowledge                                     │
+│  • Call back to host for dependencies                       │
+│  • Return large blobs via shared memory                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+When a plugin (like the template renderer) needs data, it calls back to the host:
+
+```
+Host                              Plugin (template renderer)
+  │                                        │
+  │── render(page, template_name) ────────▶│
+  │                                        │
+  │◀── resolve_template("base.html") ──────│
+  │    (picante tracks this dependency!)   │
+  │                                        │
+  │── template content ───────────────────▶│
+  │                                        │
+  │◀── resolve_template("partials/nav") ───│
+  │    (another tracked dependency!)       │
+  │                                        │
+  │── template content ───────────────────▶│
+  │                                        │
+  │◀── rendered HTML ──────────────────────│
+```
+
+The key insight: **plugin callbacks flow through picante-tracked host APIs**. When `base.html` changes later, picante knows to re-render pages that included it — even though the actual rendering happened in a separate process.
+
+## Why Not Just Memoize?
+
+Simple memoization caches function results, but without dependency tracking you can't answer:
+
+- "What depends on this input?"
+- "What needs to be recomputed when this file changes?"
+
+You'd have to either:
+1. Rebuild everything (slow)
+2. Manually specify dependencies (error-prone, stale)
+
+picante records dependencies automatically during query execution. Change a template, and only pages using that template rebuild. Change a Markdown file, and only that page re-renders. The dependency graph emerges from actual runtime behavior.
+
+## Cache Persistence
+
+The dependency graph and cached query results persist to disk via [facet-postcard](https://github.com/facet-rs/facet). Even a cold start benefits from previous work:
+
+```
+.cache/
+├── cas/                    # content-addressed storage (large blobs)
+│   ├── images/
+│   └── fonts/
+└── picante.bin            # picante's serialized cache (small!)
+```
+
+Large outputs (processed images, subsetted fonts) live in content-addressed storage, keeping the picante database lean. Only hashes are stored in picante — actual blobs are retrieved from CAS on demand.
+
+## Summary
+
+picante provides:
+- **Async queries** that work naturally with tokio
+- **Automatic dependency tracking** during execution
+- **Memoization** with proper invalidation
+- **Persistence** via facet-postcard
+- **Snapshots** for consistent reads (MVCC)
+
+It's the incremental computation engine, focused and minimal. Higher-level concerns (file watching, blob storage, RPC) live in other crates like [tacos](https://github.com/bearcove/tacos).


### PR DESCRIPTION
## Summary

Updates the website documentation to accurately reflect picante's current capabilities and provide much more context about motivation and architecture.

## Changes

### motivation.md (major expansion)
- Added "The Problem" section explaining why incremental computation matters
- Added "The Stack" section showing the picante/tacos/application layering
- Added full dodeca architecture diagram showing how picante, CAS, and plugins work together
- Added plugin callback sequence diagram showing how dependencies are tracked across process boundaries
- Added "Why Not Just Memoize?" section explaining the value of dependency tracking
- Added "Cache Persistence" section explaining the CAS + picante.bin structure
- Mentioned [tacos](https://github.com/bearcove/tacos) as the build-system layer

### future.md
- Moved already-implemented features to a new "Already implemented" section:
  - Database snapshots
  - Dependency-based revalidation  
  - Output fingerprinting (changed_at tracking)
- Remaining future work: cross-task cycle detection, accumulators, cache limits, parallel query execution

### comparisons.md
- Added new "MVCC vs cooperative locking" section explaining the fundamental difference:
  - **salsa**: Cooperative locking with cancellation — queries may be cancelled and restarted when inputs change
  - **picante**: MVCC via `im::HashMap` structural sharing — cheap O(1) snapshots for point-in-time views
- Added MVCC snapshots to the key differences list

### guide index
- Updated description to mention snapshots

Closes #23