### PR TITLE
Address PR feedback for WAL implementation

### DIFF
--- a/crates/picante/src/ingredient/derived.rs
+++ b/crates/picante/src/ingredient/derived.rs
@@ -1208,7 +1208,7 @@ where
     fn save_incremental_records(
         &self,
         since_revision: u64,
-    ) -> BoxFuture<'_, PicanteResult<Vec<(Vec<u8>, Option<Vec<u8>>)>>> {
+    ) -> BoxFuture<'_, PicanteResult<Vec<(u64, Vec<u8>, Option<Vec<u8>>)>>> {
         Box::pin(async move {
             // Collect snapshot under lock, then release before async work
             let snapshot: Vec<(DynKey, Arc<ErasedCell>)> = {
@@ -1289,7 +1289,7 @@ where
                     })
                 })?;
 
-                changes.push((key_bytes, Some(value_bytes)));
+                changes.push((changed_at.0, key_bytes, Some(value_bytes)));
             }
 
             debug!(

--- a/crates/picante/src/ingredient/input.rs
+++ b/crates/picante/src/ingredient/input.rs
@@ -281,7 +281,7 @@ where
     fn save_incremental_records(
         &self,
         since_revision: u64,
-    ) -> BoxFuture<'_, PicanteResult<Vec<(Vec<u8>, Option<Vec<u8>>)>>> {
+    ) -> BoxFuture<'_, PicanteResult<Vec<(u64, Vec<u8>, Option<Vec<u8>>)>>> {
         Box::pin(async move {
             let entries = self.entries.read();
             let mut changes = Vec::new();
@@ -308,7 +308,7 @@ where
                         None
                     };
 
-                    changes.push((key_bytes, value_bytes));
+                    changes.push((entry.changed_at.0, key_bytes, value_bytes));
                 }
             }
 

--- a/crates/picante/src/ingredient/interned.rs
+++ b/crates/picante/src/ingredient/interned.rs
@@ -206,7 +206,7 @@ where
     fn save_incremental_records(
         &self,
         _since_revision: u64,
-    ) -> BoxFuture<'_, PicanteResult<Vec<(Vec<u8>, Option<Vec<u8>>)>>> {
+    ) -> BoxFuture<'_, PicanteResult<Vec<(u64, Vec<u8>, Option<Vec<u8>>)>>> {
         Box::pin(async move {
             // For interned ingredients, we don't track revisions per entry.
             // Since interned values are immutable (never modified or deleted),


### PR DESCRIPTION
## Summary

Addresses all feedback from the WAL PR review. The critical fix is resolving revision tracking so the WAL preserves accurate `changed_at` timestamps for each change instead of losing this information.

## Changes

- **Fixed revision tracking**: Updated `save_incremental_records` to return `(revision, key, value)` tuples including the actual `changed_at` revision for each change
- **Added validation**: WAL replay now verifies snapshot revision matches WAL base revision to prevent corruption
- **Improved file detection**: Use proper `io::ErrorKind::NotFound` instead of string matching for platform independence  
- **Made compaction atomic**: Write to temporary file then atomically rename to ensure consistency even if operations fail
- **Updated documentation**: Fixed example code to show actual API usage

All tests pass including new revision tracking assertions.

## Test Plan

- [x] All existing tests pass
- [x] New revision tracking test assertions verify `changed_at` preservation
- [x] Clippy and linting checks pass