### PR TITLE
Switch from facet-postcard to facet-format-postcard with JIT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,16 +12,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
-name = "arborium"
-version = "2.4.5"
+name = "anyhow"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9c19ba649224dacd08351c21053f5e026351ed56f65c204472a67cf2d5da0a"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arborium"
+version = "2.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85659571af2a9e48e17a2f5d3f74acbb3cc0539bd68d549ee5702fd000d020ac"
 dependencies = [
  "arborium-highlight",
  "arborium-json",
@@ -33,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-highlight"
-version = "2.4.5"
+version = "2.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8effa51a0d2ac2978b7ab6d5a011f8d4a4f2ef9fcb4a0e7473960ee382a96e52"
+checksum = "599d4350479793d0bbca4f8879177dccb68f923f373fe9a0768f30f00736bc09"
 dependencies = [
  "arborium-theme",
  "arborium-tree-sitter",
@@ -44,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-json"
-version = "2.4.5"
+version = "2.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1476c6f5f1a6e15c8152b975f5f231672fe31261ba21c6cd18687016cf3c2130"
+checksum = "1093b6a202a6fb75a290dbe1b8349e6883c6af4eac8767aaba544a4343d6925f"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -55,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-rust"
-version = "2.4.5"
+version = "2.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5e840704bdc8d85a083e5f4ca49e4725e25678084949ccfd8adda5628f7946"
+checksum = "2111efc44bb3579fac7d968997cda89f1c4064fbff0986ecdf25960192d94ff3"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -66,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-sysroot"
-version = "2.4.5"
+version = "2.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66eb41995faa93ad3245fcc0c15ed3b0f7e6ece15dbe1932c41816063be4218"
+checksum = "67b6ad3c1ecab817784bd51085b17ddc93fbbb11da2dd2cfc5f20fa21e96a6dd"
 dependencies = [
  "cc",
  "dlmalloc",
@@ -76,15 +94,15 @@ dependencies = [
 
 [[package]]
 name = "arborium-theme"
-version = "2.4.5"
+version = "2.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac2e6f6a8a390fe86237435c68eb0ca60a3a7173acc064c9ddfaee7846ab365"
+checksum = "8948547cd60422c49cfa40859f54f7b05f27f1bdd9f50900456ed6da284b919c"
 
 [[package]]
 name = "arborium-tree-sitter"
-version = "2.4.5"
+version = "2.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e759f6b8106b5a42cc5c650a2fb86548b5a054ac8171a06909696de8271085"
+checksum = "d4573d1ebd312b243370ff9adc9d4a46d49c013c4e711abc9ba631f9df96a4e3"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -102,6 +120,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -116,10 +140,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.50"
+name = "bumpalo"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+dependencies = [
+ "allocator-api2",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -162,6 +195,178 @@ name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
+
+[[package]]
+name = "cranelift"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68971376deb1edf5e9c0ac77ef00479d740ce7a60e6181adb0648afe1dc7b8f4"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-module",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30054f4aef4d614d37f27d5b77e36e165f0b27a71563be348e7c9fcfac41eed8"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beab56413879d4f515e08bcf118b1cb85f294129bb117057f573d37bfbb925a"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d054747549a69b264d5299c8ca1b0dd45dc6bd0ee43f1edfcc42a8b12952c7a"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b92d481b77a7dc9d07c96e24a16f29e0c9c27d042828fdf7e49e54ee9819bf"
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eeccfc043d599b0ef1806942707fc51cdd1c3965c343956dc975a55d82a920f"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.15.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1174cdb9d9d43b2bdaa612a07ed82af13db9b95526bc2c286c2aec4689bcc038"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d572be73fae802eb115f45e7e67a9ed16acb4ee683b67c4086768786545419a"
+
+[[package]]
+name = "cranelift-control"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1587465cc84c5cc793b44add928771945f3132bbf6b3621ee9473c631a87156"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063b83448b1343e79282c3c7cbda7ed5f0816f0b763a4c15f7cecb0a17d87ea6"
+dependencies = [
+ "cranelift-bitset",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4461c2d2ca48bc72883f5f5c3129d9aefac832df1db824af9db8db3efee109"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd811b25e18f14810d09c504e06098acc1d9dbfa24879bf0d6b6fb44415fc66"
+
+[[package]]
+name = "cranelift-jit"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01527663ba63c10509d7c87fd1f8495d21170ba35bf714f57271495689d8fde5"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-module",
+ "cranelift-native",
+ "libc",
+ "log",
+ "region",
+ "target-lexicon",
+ "wasmtime-internal-jit-icache-coherence",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "cranelift-module"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72328edb49aeafb1655818c91c476623970cb7b8a89ffbdadd82ce7d13dedc1d"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2417046989d8d6367a55bbab2e406a9195d176f4779be4aa484d645887217d37"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d039de901c8d928222b8128e1b9a9ab27b82a7445cb749a871c75d9cb25c57d"
 
 [[package]]
 name = "dashmap"
@@ -230,8 +435,8 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.34.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#e972a3cfe022be819f048d411482aaacff59ceae"
+version = "0.35.0"
+source = "git+https://github.com/facet-rs/facet?branch=main#f994ae2b16d2630d06e6527006ebf781ad848a6b"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -241,17 +446,47 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.34.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#e972a3cfe022be819f048d411482aaacff59ceae"
+version = "0.35.0"
+source = "git+https://github.com/facet-rs/facet?branch=main#f994ae2b16d2630d06e6527006ebf781ad848a6b"
 dependencies = [
  "autocfg",
  "impls",
 ]
 
 [[package]]
+name = "facet-format"
+version = "0.35.0"
+source = "git+https://github.com/facet-rs/facet?branch=main#f994ae2b16d2630d06e6527006ebf781ad848a6b"
+dependencies = [
+ "cranelift",
+ "cranelift-jit",
+ "cranelift-module",
+ "cranelift-native",
+ "facet-core",
+ "facet-reflect",
+ "facet-solver",
+ "libc",
+ "museair",
+ "parking_lot",
+]
+
+[[package]]
+name = "facet-format-postcard"
+version = "0.35.0"
+source = "git+https://github.com/facet-rs/facet?branch=main#f994ae2b16d2630d06e6527006ebf781ad848a6b"
+dependencies = [
+ "facet-core",
+ "facet-format",
+ "facet-path",
+ "facet-reflect",
+ "miette",
+ "tracing",
+]
+
+[[package]]
 name = "facet-macro-parse"
-version = "0.34.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#e972a3cfe022be819f048d411482aaacff59ceae"
+version = "0.35.0"
+source = "git+https://github.com/facet-rs/facet?branch=main#f994ae2b16d2630d06e6527006ebf781ad848a6b"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -260,8 +495,8 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-types"
-version = "0.34.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#e972a3cfe022be819f048d411482aaacff59ceae"
+version = "0.35.0"
+source = "git+https://github.com/facet-rs/facet?branch=main#f994ae2b16d2630d06e6527006ebf781ad848a6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -270,16 +505,16 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.34.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#e972a3cfe022be819f048d411482aaacff59ceae"
+version = "0.35.0"
+source = "git+https://github.com/facet-rs/facet?branch=main#f994ae2b16d2630d06e6527006ebf781ad848a6b"
 dependencies = [
  "facet-macros-impl",
 ]
 
 [[package]]
 name = "facet-macros-impl"
-version = "0.34.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#e972a3cfe022be819f048d411482aaacff59ceae"
+version = "0.35.0"
+source = "git+https://github.com/facet-rs/facet?branch=main#f994ae2b16d2630d06e6527006ebf781ad848a6b"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -291,8 +526,8 @@ dependencies = [
 
 [[package]]
 name = "facet-path"
-version = "0.34.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#e972a3cfe022be819f048d411482aaacff59ceae"
+version = "0.35.0"
+source = "git+https://github.com/facet-rs/facet?branch=main#f994ae2b16d2630d06e6527006ebf781ad848a6b"
 dependencies = [
  "arborium",
  "facet-core",
@@ -302,21 +537,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "facet-postcard"
-version = "0.34.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#e972a3cfe022be819f048d411482aaacff59ceae"
-dependencies = [
- "facet-core",
- "facet-path",
- "facet-reflect",
- "log",
- "miette",
-]
-
-[[package]]
 name = "facet-pretty"
-version = "0.34.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#e972a3cfe022be819f048d411482aaacff59ceae"
+version = "0.35.0"
+source = "git+https://github.com/facet-rs/facet?branch=main#f994ae2b16d2630d06e6527006ebf781ad848a6b"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -325,18 +548,34 @@ dependencies = [
 
 [[package]]
 name = "facet-reflect"
-version = "0.34.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#e972a3cfe022be819f048d411482aaacff59ceae"
+version = "0.35.0"
+source = "git+https://github.com/facet-rs/facet?branch=main#f994ae2b16d2630d06e6527006ebf781ad848a6b"
 dependencies = [
  "facet-core",
  "miette",
 ]
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.5"
+name = "facet-solver"
+version = "0.35.0"
+source = "git+https://github.com/facet-rs/facet?branch=main#f994ae2b16d2630d06e6527006ebf781ad848a6b"
+dependencies = [
+ "facet-core",
+ "facet-reflect",
+ "strsim",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
 name = "futures-core"
@@ -364,6 +603,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +624,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hashbrown"
@@ -425,9 +681,9 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "itoa"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "lazy_static"
@@ -440,6 +696,12 @@ name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linux-raw-sys"
@@ -461,6 +723,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -486,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "miette-arborium"
-version = "2.4.5"
+version = "2.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f75fc70f7755745f224cae03ae00ae566deb1f2b4402fc012b59e3f234c1889"
+checksum = "8866f273caa1c940f0afe8f888652198e12fbf53fda066b9b3e4b1e6c4437cb9"
 dependencies = [
  "arborium",
  "arborium-highlight",
@@ -496,6 +767,12 @@ dependencies = [
  "miette",
  "owo-colors",
 ]
+
+[[package]]
+name = "museair"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41311b1064dea78399acd92ca903b13be1120eef0a8555803da792e2c50511"
 
 [[package]]
 name = "mutants"
@@ -555,7 +832,7 @@ dependencies = [
  "divan",
  "facet",
  "facet-core",
- "facet-postcard",
+ "facet-format-postcard",
  "facet-reflect",
  "futures-util",
  "im",
@@ -592,9 +869,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
 ]
@@ -629,7 +906,21 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e249c660440317032a71ddac302f25f1d5dff387667bcc3978d1f77aa31ac34"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -668,6 +959,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,18 +982,12 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
 
 [[package]]
 name = "scopeguard"
@@ -729,15 +1026,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.146"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217ca874ae0207aac254aa02c957ded05585a90892cc8d87f9e5fa49669dadd8"
+checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -785,6 +1082,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -835,6 +1138,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
 name = "target-triple"
@@ -1058,6 +1367,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "39.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97ccd36e25390258ce6720add639ffe5a7d81a5c904350aa08f5bbc60433d22"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "39.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1b856e1bbf0230ab560ba4204e944b141971adc4e6cdf3feb6979c1a7b7953"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,11 +1404,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1092,20 +1431,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1115,9 +1476,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1127,9 +1500,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1139,15 +1524,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1160,3 +1563,9 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
+name = "zmij"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d6085d62852e35540689d1f97ad663e3971fc19cf5eceab364d62c646ea167"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ im = "15.1.0"
 divan = "0.1"
 facet = { git = "https://github.com/facet-rs/facet", branch = "main" }
 facet-core = { git = "https://github.com/facet-rs/facet", branch = "main" }
-facet-postcard = { git = "https://github.com/facet-rs/facet", branch = "main" }
+facet-format-postcard = { git = "https://github.com/facet-rs/facet", branch = "main", features = ["jit"] }
 facet-reflect = { git = "https://github.com/facet-rs/facet", branch = "main" }
 heck = "0.5.0"
 parking_lot = "0.12.4"

--- a/crates/picante/Cargo.toml
+++ b/crates/picante/Cargo.toml
@@ -21,7 +21,7 @@ im.workspace = true
 facet.workspace = true
 facet-core.workspace = true
 facet-reflect.workspace = true
-facet-postcard.workspace = true
+facet-format-postcard.workspace = true
 futures-util = { version = "0.3.31", default-features = false, features = ["std", "async-await"] }
 parking_lot.workspace = true
 tokio.workspace = true

--- a/crates/picante/src/ingredient/derived.rs
+++ b/crates/picante/src/ingredient/derived.rs
@@ -921,7 +921,7 @@ where
             deps,
         };
 
-        facet_postcard::to_vec(&rec).map_err(|e| {
+        facet_format_postcard::to_vec(&rec).map_err(|e| {
             Arc::new(PicanteError::Encode {
                 what: "derived record",
                 message: format!("{e:?}"),
@@ -937,7 +937,7 @@ where
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     |kind, bytes| {
-        let rec: DerivedRecord<K, V> = facet_postcard::from_slice(bytes).map_err(|e| {
+        let rec: DerivedRecord<K, V> = facet_format_postcard::from_slice(bytes).map_err(|e| {
             Arc::new(PicanteError::Decode {
                 what: "derived record",
                 message: format!("{e:?}"),
@@ -1017,14 +1017,14 @@ where
             deps: dep_records,
         };
 
-        let key_bytes = facet_postcard::to_vec(&key).map_err(|e| {
+        let key_bytes = facet_format_postcard::to_vec(&key).map_err(|e| {
             Arc::new(PicanteError::Encode {
                 what: "derived key",
                 message: format!("{e:?}"),
             })
         })?;
 
-        let value_bytes = facet_postcard::to_vec(&rec).map_err(|e| {
+        let value_bytes = facet_format_postcard::to_vec(&rec).map_err(|e| {
             Arc::new(PicanteError::Encode {
                 what: "derived record",
                 message: format!("{e:?}"),
@@ -1042,7 +1042,7 @@ where
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     |kind, key_bytes, value_bytes| {
-        let key: K = facet_postcard::from_slice(key_bytes).map_err(|e| {
+        let key: K = facet_format_postcard::from_slice(key_bytes).map_err(|e| {
             Arc::new(PicanteError::Decode {
                 what: "derived key from WAL",
                 message: format!("{e:?}"),
@@ -1057,7 +1057,7 @@ where
         if let Some(value_bytes) = value_bytes {
             // Deserialize the full DerivedRecord
             let rec: DerivedRecord<K, V> =
-                facet_postcard::from_slice(value_bytes).map_err(|e| {
+                facet_format_postcard::from_slice(value_bytes).map_err(|e| {
                     Arc::new(PicanteError::Decode {
                         what: "derived record from WAL",
                         message: format!("{e:?}"),

--- a/crates/picante/src/ingredient/input.rs
+++ b/crates/picante/src/ingredient/input.rs
@@ -241,7 +241,7 @@ where
                     value: entry.value.clone(),
                     changed_at: entry.changed_at.0,
                 };
-                let bytes = facet_postcard::to_vec(&rec).map_err(|e| {
+                let bytes = facet_format_postcard::to_vec(&rec).map_err(|e| {
                     Arc::new(PicanteError::Encode {
                         what: "input record",
                         message: format!("{e:?}"),
@@ -261,12 +261,13 @@ where
     fn load_records(&self, records: Vec<Vec<u8>>) -> PicanteResult<()> {
         let mut entries = self.entries.write();
         for bytes in records {
-            let rec: InputRecord<K, V> = facet_postcard::from_slice(&bytes).map_err(|e| {
-                Arc::new(PicanteError::Decode {
-                    what: "input record",
-                    message: format!("{e:?}"),
-                })
-            })?;
+            let rec: InputRecord<K, V> =
+                facet_format_postcard::from_slice(&bytes).map_err(|e| {
+                    Arc::new(PicanteError::Decode {
+                        what: "input record",
+                        message: format!("{e:?}"),
+                    })
+                })?;
             entries.insert(
                 rec.key,
                 InputEntry {
@@ -289,7 +290,7 @@ where
             for (key, entry) in entries.iter() {
                 // Only include entries that changed after the base revision
                 if entry.changed_at.0 > since_revision {
-                    let key_bytes = facet_postcard::to_vec(key).map_err(|e| {
+                    let key_bytes = facet_format_postcard::to_vec(key).map_err(|e| {
                         Arc::new(PicanteError::Encode {
                             what: "input key",
                             message: format!("{e:?}"),
@@ -297,7 +298,7 @@ where
                     })?;
 
                     let value_bytes = if let Some(value) = &entry.value {
-                        let bytes = facet_postcard::to_vec(value).map_err(|e| {
+                        let bytes = facet_format_postcard::to_vec(value).map_err(|e| {
                             Arc::new(PicanteError::Encode {
                                 what: "input value",
                                 message: format!("{e:?}"),
@@ -329,7 +330,7 @@ where
         key: Vec<u8>,
         value: Option<Vec<u8>>,
     ) -> PicanteResult<()> {
-        let key: K = facet_postcard::from_slice(&key).map_err(|e| {
+        let key: K = facet_format_postcard::from_slice(&key).map_err(|e| {
             Arc::new(PicanteError::Decode {
                 what: "input key from WAL",
                 message: format!("{e:?}"),
@@ -337,7 +338,7 @@ where
         })?;
 
         let value: Option<V> = if let Some(bytes) = value {
-            Some(facet_postcard::from_slice(&bytes).map_err(|e| {
+            Some(facet_format_postcard::from_slice(&bytes).map_err(|e| {
                 Arc::new(PicanteError::Decode {
                     what: "input value from WAL",
                     message: format!("{e:?}"),

--- a/crates/picante/src/ingredient/interned.rs
+++ b/crates/picante/src/ingredient/interned.rs
@@ -145,7 +145,7 @@ where
             for (id, value) in snapshot {
                 let rec = InternedRecord::<K> { id: id.0, value };
 
-                let bytes = facet_postcard::to_vec(&rec).map_err(|e| {
+                let bytes = facet_format_postcard::to_vec(&rec).map_err(|e| {
                     Arc::new(PicanteError::Encode {
                         what: "interned record",
                         message: format!("{e:?}"),
@@ -169,12 +169,13 @@ where
         let mut max_id: u32 = 0;
 
         for bytes in records {
-            let rec: InternedRecord<K> = facet_postcard::from_slice(&bytes).map_err(|e| {
-                Arc::new(PicanteError::Decode {
-                    what: "interned record",
-                    message: format!("{e:?}"),
-                })
-            })?;
+            let rec: InternedRecord<K> =
+                facet_format_postcard::from_slice(&bytes).map_err(|e| {
+                    Arc::new(PicanteError::Decode {
+                        what: "interned record",
+                        message: format!("{e:?}"),
+                    })
+                })?;
 
             let id = InternId(rec.id);
             max_id = max_id.max(id.0);
@@ -245,12 +246,13 @@ where
         // (e.g., from a future version that does track them).
 
         if let Some(value_bytes) = value {
-            let rec: InternedRecord<K> = facet_postcard::from_slice(&value_bytes).map_err(|e| {
-                Arc::new(PicanteError::Decode {
-                    what: "interned record from WAL",
-                    message: format!("{e:?}"),
-                })
-            })?;
+            let rec: InternedRecord<K> =
+                facet_format_postcard::from_slice(&value_bytes).map_err(|e| {
+                    Arc::new(PicanteError::Decode {
+                        what: "interned record from WAL",
+                        message: format!("{e:?}"),
+                    })
+                })?;
 
             let id = InternId(rec.id);
             let key = Key::encode_facet(rec.value.as_ref())?;

--- a/crates/picante/src/key.rs
+++ b/crates/picante/src/key.rs
@@ -45,7 +45,7 @@ pub struct Key {
 impl Key {
     /// Encode a key using `facet-postcard`.
     pub fn encode_facet<T: Facet<'static>>(value: &T) -> PicanteResult<Self> {
-        let bytes = facet_postcard::to_vec(value).map_err(|e| {
+        let bytes = facet_format_postcard::to_vec(value).map_err(|e| {
             Arc::new(PicanteError::Encode {
                 what: "key",
                 message: format!("{e:?}"),
@@ -56,7 +56,7 @@ impl Key {
 
     /// Decode a key using `facet-postcard`.
     pub fn decode_facet<T: Facet<'static>>(&self) -> PicanteResult<T> {
-        facet_postcard::from_slice(self.bytes()).map_err(|e| {
+        facet_format_postcard::from_slice(self.bytes()).map_err(|e| {
             Arc::new(PicanteError::Decode {
                 what: "key",
                 message: format!("{e:?}"),

--- a/crates/picante/src/persist.rs
+++ b/crates/picante/src/persist.rs
@@ -396,7 +396,7 @@ fn ensure_unique_kinds(ingredients: &[&dyn PersistableIngredient]) -> PicanteRes
 }
 
 fn encode_cache_file(cache: &CacheFile) -> PicanteResult<Vec<u8>> {
-    facet_postcard::to_vec(cache).map_err(|e| {
+    facet_format_postcard::to_vec(cache).map_err(|e| {
         Arc::new(PicanteError::Encode {
             what: "cache file",
             message: format!("{e:?}"),
@@ -405,7 +405,7 @@ fn encode_cache_file(cache: &CacheFile) -> PicanteResult<Vec<u8>> {
 }
 
 fn decode_cache_file(bytes: &[u8]) -> PicanteResult<CacheFile> {
-    facet_postcard::from_slice(bytes).map_err(|e| {
+    facet_format_postcard::from_slice(bytes).map_err(|e| {
         Arc::new(PicanteError::Decode {
             what: "cache file",
             message: format!("{e:?}"),

--- a/crates/picante/src/wal.rs
+++ b/crates/picante/src/wal.rs
@@ -168,7 +168,7 @@ impl WalWriter {
             format_version: WAL_FORMAT_VERSION,
             base_revision,
         };
-        let header_bytes = facet_postcard::to_vec(&header).map_err(|e| {
+        let header_bytes = facet_format_postcard::to_vec(&header).map_err(|e| {
             Arc::new(PicanteError::Encode {
                 what: "WAL header",
                 message: format!("{}", e),
@@ -209,7 +209,7 @@ impl WalWriter {
     /// is reached or when `flush()` is called explicitly.
     pub fn append(&mut self, entry: WalEntry) -> PicanteResult<()> {
         // Serialize the entry
-        let entry_bytes = facet_postcard::to_vec(&entry).map_err(|e| {
+        let entry_bytes = facet_format_postcard::to_vec(&entry).map_err(|e| {
             Arc::new(PicanteError::Encode {
                 what: "WAL entry",
                 message: format!("{}", e),
@@ -343,7 +343,7 @@ impl WalReader {
             })
         })?;
 
-        let header: WalHeader = facet_postcard::from_slice(&header_bytes).map_err(|e| {
+        let header: WalHeader = facet_format_postcard::from_slice(&header_bytes).map_err(|e| {
             Arc::new(PicanteError::Decode {
                 what: "WAL header",
                 message: format!("{}", e),
@@ -413,7 +413,7 @@ impl WalReader {
             })
         })?;
 
-        let entry: WalEntry = facet_postcard::from_slice(&entry_bytes).map_err(|e| {
+        let entry: WalEntry = facet_format_postcard::from_slice(&entry_bytes).map_err(|e| {
             Arc::new(PicanteError::Decode {
                 what: "WAL entry",
                 message: format!("{}", e),

--- a/crates/picante/tests/persist.rs
+++ b/crates/picante/tests/persist.rs
@@ -232,7 +232,7 @@ async fn load_cache_ignores_unknown_sections() {
         ],
     };
 
-    let bytes = facet_postcard::to_vec(&cache).unwrap();
+    let bytes = facet_format_postcard::to_vec(&cache).unwrap();
     tokio::fs::write(&cache_path, bytes).await.unwrap();
 
     let db = TestDb::default();
@@ -279,7 +279,7 @@ async fn load_cache_kind_name_mismatch_is_warning() {
         }],
     };
 
-    let bytes = facet_postcard::to_vec(&cache).unwrap();
+    let bytes = facet_format_postcard::to_vec(&cache).unwrap();
     tokio::fs::write(&cache_path, bytes).await.unwrap();
 
     let db = TestDb::default();


### PR DESCRIPTION
## Summary

- Replace `facet-postcard` with `facet-format-postcard` (with `jit` feature enabled)
- This uses Cranelift for JIT-accelerated deserialization
- Drop-in replacement with the same API