### PR TITLE
Prepare picante 3.0.0-rc.0

### DIFF
--- a/.config/dodeca.styx
+++ b/.config/dodeca.styx
@@ -14,8 +14,8 @@ code_execution {
     cache_dir .cache/code-execution
     dependencies (
         {name tokio, version "1.0"}
-        {name picante, version "0.1.0", path crates/picante}
-        {name facet, version "0.32.2"}
+        {name picante, version "3.0.0-rc.0", path crates/picante}
+        {name facet, version "0.50.0-rc.0"}
     )
     rust {
         command cargo

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - bearcove-ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -94,4 +96,3 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --workspace --all-features --no-deps
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: cargo bench --workspace --all-features --no-run
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: cargo bench --workspace --all-features --no-run
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: Test + Coverage
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 
@@ -49,7 +49,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 
@@ -66,7 +66,7 @@ jobs:
 
   fmt:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 
@@ -80,7 +80,7 @@ jobs:
 
   doc:
     name: Docs
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 
@@ -48,7 +48,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,10 +37,10 @@ jobs:
         working-directory: docs
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/public
 
@@ -53,5 +53,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -16,7 +16,7 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -40,17 +40,45 @@ jobs:
       group: release-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.92
 
-      - name: Authenticate to crates.io (OIDC)
+      - name: Get crates.io token via OIDC
         id: crates-io-auth
-        uses: rust-lang/crates-io-auth-action@v1
+        shell: bash
+        env:
+          REGISTRY_URL: https://crates.io
+        run: |
+          set -euo pipefail
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "::error::Please ensure the 'id-token' permission is set to 'write' in your workflow."
+            exit 1
+          fi
 
+          oidc_url="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=crates.io"
+          jwt="$(curl -fsSL -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${oidc_url}" | jq -r '.value')"
+          if [ -z "${jwt}" ] || [ "${jwt}" = "null" ]; then
+            echo "::error::Failed to retrieve GitHub Actions OIDC token"
+            exit 1
+          fi
+
+          token="$(jq -n --arg jwt "${jwt}" '{jwt: $jwt}' \
+            | curl -fsSL -X POST "${REGISTRY_URL}/api/v1/trusted_publishing/tokens" \
+                -H "Content-Type: application/json" \
+                -H "User-Agent: crates-io-auth-shell/1" \
+                --data @- \
+            | jq -r '.token')"
+          if [ -z "${token}" ] || [ "${token}" = "null" ]; then
+            echo "::error::Failed to retrieve crates.io token"
+            exit 1
+          fi
+
+          echo "::add-mask::${token}"
+          echo "token=${token}" >> "${GITHUB_OUTPUT}"
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
@@ -58,3 +86,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+      - name: Revoke crates.io token
+        if: always() && steps.crates-io-auth.outputs.token != ''
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+          REGISTRY_URL: https://crates.io
+        run: |
+          set -euo pipefail
+          curl -fsSL -X DELETE "${REGISTRY_URL}/api/v1/trusted_publishing/tokens" \
+            -H "Authorization: Bearer ${CARGO_REGISTRY_TOKEN}" \
+            -H "User-Agent: crates-io-auth-shell/1" \
+            --output /dev/null

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-pr:
     name: Release PR
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: bearcove-ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write
@@ -32,7 +32,7 @@ jobs:
 
   release:
     name: Publish
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: bearcove-ubuntu-24.04
     permissions:
       contents: write
       id-token: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa36099ca72f6fb53a63284034ecc747901103cc9ff2c37a3395056ff7bbae12"
+checksum = "b8d43d3564e06baf09ca8ab87072e49e603046af471f1ed68cbeb1ad3ec8fba2"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6691a60d328fa343c3bc34bb2dd2778f402b98aa774d52829a3d0572bcb98815"
+checksum = "a088a24ab676d6a7ed5ae3a7982a2092cc29684fe4e97b3827d5e239c76d9e79"
 dependencies = [
  "autocfg",
  "const-fnv1a-hash",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "facet-dessert"
-version = "0.46.0"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4505ec8ef086d776fd99b86fb17e3d1c711188d27aa72845e64a30146226e3b"
+checksum = "93bcd8bfe96797c30bb5cbc7af19854bc793bcc29e884f3caea55ab4d0a76cf2"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "facet-format"
-version = "0.47.1"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2353807588cc4057a5e31bf459e7304ea84729ad77080e267928b1e09d36235"
+checksum = "bd9f89149e4d373016b1e9f263ce5f9e2171a432163badc3353cfbe3c8a5960f"
 dependencies = [
  "facet-core",
  "facet-dessert",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-parse"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671db275c95fe788e8c488e72221f55b78863dec510a48131b4517ba398f716a"
+checksum = "1a85e100b892473cef064ca8f3443af4c8eb78b8609eb3224eba8df679caf690"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-types"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f893ca809a6b5a1caffa3ebf9e88c7720793cde82a6b809b1e65f19b095ed2be"
+checksum = "87b2552407f6f584187a808bd4fbb56f002cc5451454294898276881c232d07a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -219,18 +219,18 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f8e1bfcea82611508c06b670ec34e7957827fefc02a0982eee2e75002ee05d"
+checksum = "b77f92b6fe3ae6d45544e50351a9a54f7190240220b283916cbcca20a849812b"
 dependencies = [
  "facet-macros-impl",
 ]
 
 [[package]]
 name = "facet-macros-impl"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7517702043f5656a6ee7de64bf8b26a549dbbfe983f592be29bead7ff380d798"
+checksum = "cd1f0535febaea47d61f5386a6e0ab3249a5aaf813ae67e25bf285e97c481e30"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -242,18 +242,18 @@ dependencies = [
 
 [[package]]
 name = "facet-path"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7ec0955c6ed58229b136c1c8c5b9d9c93d7af4317b8f7a570bda726243c626"
+checksum = "4f0aeceb55a22d6ddb1d9d2af4a6223114ce6869821c0ae1091a3c955d1492a7"
 dependencies = [
  "facet-core",
 ]
 
 [[package]]
 name = "facet-postcard"
-version = "0.46.1"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d8c0d08c0294d3991e6b853038935bb0f89667652439050cf3fdedcded8451"
+checksum = "c73808e09fce1ee54cf8e2a70fa301bcb8a1c92ffc3ea2d18ab2e83adbec1c46"
 dependencies = [
  "facet-core",
  "facet-format",
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "facet-reflect"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304dd81b64f2f759735e9044c6cb2c8b9e5ad7d004bdf1b27dd7b2f2285c0e3e"
+checksum = "8287a68023eec4152a4d4cb88814e10d38ff6f116cbb70acb4eb58a304f624c6"
 dependencies = [
  "facet-core",
  "facet-path",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "facet-solver"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16981fb80d2946389bc2dd3789e53c6f5cf1be3f25186f66f8582f748a03adf0"
+checksum = "f1d5bfeaa1e0dcbdfccf86b6f64e258b4d2db839b1573f0bbff8ee27a45a9fbc"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "facet-value"
-version = "0.46.0"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c61477bcef8cda3ba1082f25ad69569792214f9d430671afb32e9cdedbce6d7"
+checksum = "01766190652de0ce73460cf68addaf6dc4180e0f84363f0a419f5645bc03aca8"
 dependencies = [
  "facet-core",
  "facet-format",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "picante"
-version = "2.0.1"
+version = "3.0.0-rc.0"
 dependencies = [
  "dashmap",
  "divan",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "picante-macros"
-version = "2.0.1"
+version = "3.0.0-rc.0"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "2.0.1"
+version = "3.0.0-rc.0"
 edition = "2024"
 rust-version = "1.91"
 license = "Apache-2.0 OR MIT"
@@ -16,10 +16,10 @@ readme = "README.md"
 dashmap = "6"
 im = "15.1.0"
 divan = "0.1"
-facet = { version = "0.46" }
-facet-core = { version = "0.46" }
-facet-postcard = { version = "0.46" }
-facet-reflect = { version = "0.46" }
+facet = { version = "0.50.0-rc.0" }
+facet-core = { version = "0.50.0-rc.0" }
+facet-postcard = { version = "0.50.0-rc.0" }
+facet-reflect = { version = "0.50.0-rc.0" }
 heck = "0.5.0"
 parking_lot = "0.12.4"
 proc-macro2 = "1.0.101"
@@ -30,7 +30,7 @@ tracing = { version = "0.1.41", default-features = false, features = ["std"] }
 tracing-subscriber = "0.3.20"
 trybuild = "1.0"
 unsynn = "0.3.0"
-picante-macros = { version = "2.0.1", path = "crates/picante-macros" }
+picante-macros = { version = "3.0.0-rc.0", path = "crates/picante-macros" }
 
 # [patch."https://github.com/facet-rs/facet"]
 # facet = { path = "../facet/facet" }

--- a/crates/picante-macros/src/lib.rs
+++ b/crates/picante-macros/src/lib.rs
@@ -1,4 +1,8 @@
 #![warn(missing_docs)]
+#![allow(
+    clippy::result_large_err,
+    reason = "unsynn parser macros return unsynn::Error by value; unsynn tracks this as a deliberate allocation-free parser API tradeoff"
+)]
 
 //! Proc macros for Picante (`#[picante::input]`, `#[picante::tracked]`, etc.).
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -8,7 +8,7 @@ Add picante to your `Cargo.toml`:
 
 ```toml,noexec
 [dependencies]
-picante = "0.1"
+picante = "3.0.0-rc.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -94,4 +94,3 @@ pub struct AppDatabase {}
 
 fn use_db<DB: Db>(db: &DB) { /* ... */ }
 ```
-

--- a/docs/content/internals/cells.md
+++ b/docs/content/internals/cells.md
@@ -102,7 +102,7 @@ This “poisoning is revision-scoped” behavior matters when you have transient
 
 ## Cross-snapshot adoption
 
-The derived access loop also has two cross-snapshot mechanisms (documented in more detail in [In-flight Deduplication](../inflight/)):
+The derived access loop also has two cross-snapshot mechanisms (documented in more detail in [In-flight Deduplication](/internals/inflight/)):
 
 - a shared completed-result cache (“adopt a ready record if valid”)
 - a global in-flight registry (“followers await the leader across snapshots”)

--- a/docs/content/internals/tracing.md
+++ b/docs/content/internals/tracing.md
@@ -68,4 +68,4 @@ To correlate events, look for the common fields:
 
 If you’re building live reload / diagnostics tooling, consider pairing traces with the structured runtime event stream:
 
-- [Runtime Events](../events/)
+- [Runtime Events](/internals/events/)

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -87,8 +87,8 @@ title %} {% block body_class %}home{% endblock body_class %} {% block body %}
         <h2>Ready to spice up your query graph?</h2>
         <p>Check out the guide or dive into the API docs.</p>
         <div class="cta-actions">
-            <a href="/guide/architecture/" class="btn btn-primary">Read the Architecture</a>
-            <a href="/guide/motivation/" class="btn btn-secondary">Why picante?</a>
+            <a href="/internals/architecture/" class="btn btn-primary">Read the Architecture</a>
+            <a href="/internals/motivation/" class="btn btn-secondary">Why picante?</a>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary

- bump the Picante workspace crates to `3.0.0-rc.0`
- move Facet dependencies to `0.50.0-rc.0`
- modernize the cargo-llvm-cov install action and keep Linux workflows on `bearcove-ubuntu-24.04`
- document the unsynn parser `result_large_err` lint boundary in `picante-macros`
- fix internal docs links that the Dodeca build reported

## Action runtime audit

- `actions/checkout@v6`, `Swatinem/rust-cache@v2`, `actions/configure-pages@v6`, `actions/deploy-pages@v5`, nested `actions/upload-artifact@v7`, and nested `actions/github-script@v8.0.0` report `using: node24`
- `dtolnay/rust-toolchain@1.91`, `dtolnay/rust-toolchain@nightly`, `dtolnay/rust-toolchain@1.92`, `taiki-e/install-action@v2`, `codecov/codecov-action@v7`, `actions/upload-pages-artifact@v5`, `release-plz/action@v0.5`, nested `cargo-bins/cargo-binstall@v1.20.0`, and nested `release-plz/git-config` are composite actions

## Verification

- `cargo fmt --all -- --check`
- `actionlint`
- `cargo clippy --workspace --all-targets --all-features --message-format=short -- -D warnings`
- `cargo check --workspace --all-features`
- `cargo +1.91 check --workspace --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo update --workspace --locked`
- `cargo nextest list --workspace --all-features`
- `cargo nextest run --workspace --all-features` (71/71 passed)
- `ddc build --no-tui` from `docs/` (exit 0; internal links clean, external checks still fail locally for `dodeca.dev`/`facets.rs`)
- pre-push `capn` suite passed