### PR TITLE
Point Picante users to the Facet monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+> [!IMPORTANT]
+> Picante now lives in the Facet monorepo.
+
+Use [`picante`](https://github.com/facet-rs/facet/tree/main/picante) and
+[`picante-macros`](https://github.com/facet-rs/facet/tree/main/picante-macros)
+from [`facet-rs/facet`](https://github.com/facet-rs/facet) for new issues,
+pull requests, releases, and documentation.
+
+After this redirect lands, this repository will be archived.
+
 **picante** is an **async** incremental query runtime for Rust, inspired by Salsa but built for **Tokio-first** pipelines (like Dodeca).
 
 **What it has today**

--- a/README.md.in
+++ b/README.md.in
@@ -1,3 +1,13 @@
+> [!IMPORTANT]
+> Picante now lives in the Facet monorepo.
+
+Use [`picante`](https://github.com/facet-rs/facet/tree/main/picante) and
+[`picante-macros`](https://github.com/facet-rs/facet/tree/main/picante-macros)
+from [`facet-rs/facet`](https://github.com/facet-rs/facet) for new issues,
+pull requests, releases, and documentation.
+
+After this redirect lands, this repository will be archived.
+
 **picante** is an **async** incremental query runtime for Rust, inspired by Salsa but built for **Tokio-first** pipelines (like Dodeca).
 
 **What it has today**


### PR DESCRIPTION
## Summary
- add a prominent README redirect to the Picante crates now living in facet-rs/facet
- point issues, PRs, releases, and docs at the Facet monorepo
- note that this repository will be archived after the redirect lands

## Test plan
- pre-commit hook via git commit
- pre-push hook via git push